### PR TITLE
Fix for activity_weekly

### DIFF
--- a/tweets_analyzer.py
+++ b/tweets_analyzer.py
@@ -69,7 +69,7 @@ activity_hourly = {
 }
 
 activity_weekly = {
-    "%i": 0 for i in range(7)
+    "%i" % i: 0 for i in range(7)
 }
 
 detected_langs = collections.Counter()


### PR DESCRIPTION
Current version of the code creates (tested in python 2.7 and 3.4) in Ubuntu 14.04 LTS:
>>> activity_weekly
{'%i': 0}