### PR TITLE
Include required Python version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ There are plenty of things that could be added to the script, feel free to contr
 
 ⚠ First, update your API keys in the *secrets.py* file. To get API keys go to https://apps.twitter.com/
 
+Python v2.7 or newer is required
+
 You will need the following python packages installed: tweepy, ascii_graph, tqdm, numpy
 
 ```sh


### PR DESCRIPTION
Add note about Python version requirements. Sadly some of us still have Python 2.6 installed by default and have to make accommodations to get 2.7 or newer on.

One of the requirements, numpy, requires Python 2.7 or newer.

```Downloading/unpacking numpy==1.12.0 (from -r requirements.txt (line 3))
  Downloading numpy-1.12.0.zip (4.8MB): 4.8MB downloaded
  Running setup.py egg_info for package numpy
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/tmp/pip-build/numpy/setup.py", line 34, in <module>
        raise RuntimeError("Python version 2.7 or >= 3.4 required.")
    RuntimeError: Python version 2.7 or >= 3.4 required.
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/tmp/pip-build/numpy/setup.py", line 34, in <module>

    raise RuntimeError("Python version 2.7 or >= 3.4 required.")

RuntimeError: Python version 2.7 or >= 3.4 required.
```