### PR TITLE
Bump tweepy to 3.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ requests==2.19.1
 requests-oauthlib==1.0.0
 six==1.11.0
 tqdm==4.25.0
-tweepy==3.6.0
+tweepy==3.7.0
 urllib3==1.23


### PR DESCRIPTION
Fixes a SyntaxError when running on Python 3.7