### PR TITLE
Changing API Access Mode to Extended

### DIFF
--- a/tweets_analyzer.py
+++ b/tweets_analyzer.py
@@ -209,12 +209,12 @@ def get_friends(api, username, limit):
 def get_tweets(api, username, fh, limit):
     """ Download Tweets from username account """
     if args.json is False:
-        for status in tqdm(tweepy.Cursor(api.user_timeline, screen_name=username).items(limit), unit="tw", total=limit):
+        for status in tqdm(tweepy.Cursor(api.user_timeline, screen_name=username,tweet_mode="extended").items(limit), unit="tw", total=limit):
             process_tweet(status)
             if args.save:
                 fh.write(str(json.dumps(status._json))+",")
     else:
-        for status in (tweepy.Cursor(api.user_timeline, screen_name=username).items(limit)):
+        for status in (tweepy.Cursor(api.user_timeline, screen_name=username,tweet_mode="extended").items(limit)):
             process_tweet(status)
             if args.save:
                 fh.write(str(json.dumps(status._json))+",")


### PR DESCRIPTION
using the "extended" value will ensure all tweets are parsed for all 280 characters and not truncated this will ensure that users do not have to got through the process of looking through StackOverflow or the docs and editing the code; as most users will want the extended versions. It should be noted that this changes the JSON key within the return object from "text" to "full_text" however this program does not specifically use these. 